### PR TITLE
BS.null has false negatives

### DIFF
--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -4,7 +4,7 @@
 module Main (main) where
 
 import Control.Applicative ((<$>))
-import Data.List ((\\), intersect, union, nub, sort)
+import Data.List ((\\), intersect, union, nub, sort, foldl')
 import Data.Monoid ((<>), mempty)
 import Data.Word (Word16)
 import Foreign (Storable(..), allocaBytes)
@@ -79,6 +79,16 @@ propFromList xs = all (`BS.member` bs) xs where
 
 propEmpty :: Word16 -> Bool
 propEmpty x = x `BS.notMember` BS.empty
+
+propNullEmpty :: Bool
+propNullEmpty = BS.null bs where
+  bs :: BitSet Word16
+  bs = BS.empty
+
+propNullEmpty' :: [Word16] -> Bool
+propNullEmpty' xs = BS.null n where
+  n = foldl' (flip BS.delete) bs xs
+  bs = foldl' (flip BS.insert) BS.empty xs
 
 propIntersectionWithSelf :: [Word16] -> Bool
 propIntersectionWithSelf xs = all (`BS.member` bs) xs
@@ -181,6 +191,8 @@ main = defaultMain tests where
           , testProperty "toList" propToList
           , testProperty "fromList" propFromList
           , testProperty "empty" propEmpty
+          , testProperty "native empty is null" propNullEmpty
+          , testProperty "generated empty is null" propNullEmpty'
           , testProperty "intersection with self" propIntersectionWithSelf
           , testProperty "intersection" propIntersection
           , testProperty "difference with self" propDifferenceWithSelf


### PR DESCRIPTION
`BS.null` doesn't always return `True` on the cases I'd like it to. It works fine on `BS.empty`, but as soon as I inserted and deleted one or more elements, it seems to stay `False`.

The cases that work:

```
> BS.null (BS.empty :: BS.BitSet Int)
True
> BS.null (BS.delete 42 BS.empty :: BS.BitSet Int)
True
```

The case that doesn't:

```
> BS.null (BS.delete 42 $ BS.insert 42 BS.empty :: BS.BitSet Int)
False
```

It seems kind of related to the `FasterInteger` implementation: if I replace the `propNullEmpty'` test in the attached patch with the following, the test passes: (replacing `BitSet` with `GBitSet Integer`)

```
propNullEmpty' :: [Word16] -> Bool
propNullEmpty' xs = GS.null n where
  n = foldl' (flip GS.delete) bs xs :: GBitSet Integer Word16
  bs = foldl' (flip GS.insert) GS.empty xs
```

I'm not sure I understand enough of the implementation to help more than that, but it's a start!
